### PR TITLE
Add SMS extensions to Picodrive

### DIFF
--- a/FunKey/package/picodrive/opk/megadrive/megadrive.funkey-s.desktop
+++ b/FunKey/package/picodrive/opk/megadrive/megadrive.funkey-s.desktop
@@ -5,4 +5,4 @@ Icon=megadrive
 Exec=/usr/games/launchers/megadrive_launch.sh %f
 Categories=emulators
 SelectorDir=/mnt/Sega Genesis
-SelectorFilter=zip,ZIP,md,MD,bin,BIN,32x,32X,cue,CUE,cso,CSO,chd,CHD,smd,SMD,gg,GG,sg,SG
+SelectorFilter=zip,ZIP,md,MD,bin,BIN,32x,32X,cue,CUE,cso,CSO,chd,CHD,smd,SMD,gg,GG,sg,SG,sms,SMS


### PR DESCRIPTION
Changes proposed in this pull request:
- Add support for `.sms/.SMS` to the Megadrive OPK. Currently SMS ROMs don't appear and have to be renamed to one of the supported extensions. 

@funkey-project/funkey-project-admins
