### PR TITLE
Make PicoArch correctly appear in the Emulator section of GMenu2X

### DIFF
--- a/FunKey/package/picoarch/opk/picoarch/picoarch.funkey-s.desktop
+++ b/FunKey/package/picoarch/opk/picoarch/picoarch.funkey-s.desktop
@@ -3,6 +3,6 @@ Name=PicoArch
 Comment=SDL Libretro frontend
 Exec=/usr/games/picoarch %f
 Icon=picoarch
-Categories=games
+Categories=emulators
 SelectorDir=/mnt/Libretro/cores
 SelectorFilter=so


### PR DESCRIPTION
Changes proposed in this pull request:
- Make PicoArch correctly appear in the Emulator section of GMenu2X instead of the Games section

@funkey-project/funkey-project-admins
